### PR TITLE
[Fix] PostsListView TopPadding 값 수정

### DIFF
--- a/Module-MeetUP/Module-MeetUP/Screens/PostsListView/PostsListView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostsListView/PostsListView.swift
@@ -71,6 +71,11 @@ struct TotalPostsSectionView: View {
 
 struct PostsListView_Previews: PreviewProvider {
     static var previews: some View {
-        PostsListView()
+        Group {
+            PostsListView()
+                .previewDevice(PreviewDevice(rawValue: "iPhone SE"))
+            PostsListView()
+                .previewDevice(PreviewDevice(rawValue: "iPhone 13"))
+        }
     }
 }

--- a/Module-MeetUP/Module-MeetUP/Screens/PostsListView/PostsListViewComponents/PostsListTitleView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostsListView/PostsListViewComponents/PostsListTitleView.swift
@@ -19,7 +19,7 @@ struct PostsListTitleView: View {
             Spacer()
             SearchButton()
         }
-        .padding(EdgeInsets(top: 60, leading: 20, bottom: 16, trailing: 20))
+        .padding(EdgeInsets(top: hasTopNotch ? 60 : 30, leading: 20, bottom: 16, trailing: 20))
     }
 }
 


### PR DESCRIPTION
### Motivation 🥳 (코드를 추가/변경하게 된 이유)
노치가 없는 기종의 경우 TopBar가 상단과 너무 멀어져보이는 이슈 수정


### Key Changes 🔥 (주요 구현/변경 사항)
DeviceInfo 의 hasTopNotch 를 활용하여 수정


### ScreenShot 📷 (참고 사진)
<img width="300" alt="image" src="https://user-images.githubusercontent.com/103012087/191142249-b43756d2-5c5c-4cc8-852b-4f5202e65dfe.png">

### Close Issues 🔒 (닫을 Issue)
Close #13 


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 이슈 해결 완료입니다!
