### PR TITLE
SearchView 최근 검색어 삭제 구현

### DIFF
--- a/Module-MeetUP/Module-MeetUP/App/Module_MeetUPApp.swift
+++ b/Module-MeetUP/Module-MeetUP/App/Module_MeetUPApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct Module_MeetUPApp: App {
     var body: some Scene {
         WindowGroup {
-            MainView()
+            SearchView(searchStates: SearchStateHolder())
         }
     }
 }

--- a/Module-MeetUP/Module-MeetUP/App/Module_MeetUPApp.swift
+++ b/Module-MeetUP/Module-MeetUP/App/Module_MeetUPApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct Module_MeetUPApp: App {
     var body: some Scene {
         WindowGroup {
-            SearchView(searchStates: SearchStateHolder())
+            MainView()
         }
     }
 }

--- a/Module-MeetUP/Module-MeetUP/Screens/Search/SearchStateHolder.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/Search/SearchStateHolder.swift
@@ -14,7 +14,7 @@ final class SearchStateHolder: ObservableObject {
     var searchHistorys: [String] {
         get { return _searchHistorys }
         set {
-            if newValue.count > 4 {
+            if newValue.count > 5 {
                 _searchHistorys.remove(at: 0)
             }
         }

--- a/Module-MeetUP/Module-MeetUP/Screens/Search/SearchStateHolder.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/Search/SearchStateHolder.swift
@@ -25,5 +25,9 @@ final class SearchStateHolder: ObservableObject {
         searchHistorys = _searchHistorys
         searchContent = ""
     }
+    
+    func resetSearchHistorys() {
+        _searchHistorys.removeAll()
+    }
 
 }

--- a/Module-MeetUP/Module-MeetUP/Screens/Search/SearchView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/Search/SearchView.swift
@@ -15,6 +15,7 @@ struct SearchView: View {
             RecentSearchHistoryListView(searchStates: searchStates)
             Spacer()
         }
+        .ignoresSafeArea(.keyboard)
     }
 }
 

--- a/Module-MeetUP/Module-MeetUP/Screens/Search/SearchViewComponents/RecentSearchHistoryListView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/Search/SearchViewComponents/RecentSearchHistoryListView.swift
@@ -11,7 +11,7 @@ struct RecentSearchHistoryListView: View {
     @StateObject var searchStates: SearchStateHolder
     var body: some View {
         VStack(alignment: .leading, spacing: .zero) {
-            RecentSearchHistoryListTitleView()
+            RecentSearchHistoryListTitleView(searchStates: searchStates)
             ForEach(searchStates.searchHistorys, id: \.self) { recentSearchHistory in
                 RecentSearchHistoryCellView(recentHistory: recentSearchHistory)
             }
@@ -23,6 +23,7 @@ struct RecentSearchHistoryListView: View {
 }
 
 struct RecentSearchHistoryListTitleView: View {
+    @StateObject var searchStates: SearchStateHolder
     var body: some View {
         HStack(alignment:.top, spacing: .zero) {
             Text("최근 검색어")
@@ -30,7 +31,7 @@ struct RecentSearchHistoryListTitleView: View {
             Spacer()
             //TODO: 분기처리 필요
             Button {
-                //TODO: 전체 삭제 로직
+                searchStates.resetSearchHistorys()
             } label: {
                 Text("전체 삭제")
                     .font(.callout)

--- a/Module-MeetUP/Module-MeetUP/Screens/Search/SearchViewComponents/RecentSearchHistoryListView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/Search/SearchViewComponents/RecentSearchHistoryListView.swift
@@ -12,7 +12,7 @@ struct RecentSearchHistoryListView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: .zero) {
             RecentSearchHistoryListTitleView(searchStates: searchStates)
-            if searchStates._searchHistorys != [] {
+            if !searchStates._searchHistorys.isEmpty {
                 ForEach(0 ..< searchStates.searchHistorys.count, id: \.self) { recentSearchHistoryIndex in
                     RecentSearchHistoryCell(searchStates: searchStates, recentHistory: searchStates.searchHistorys[recentSearchHistoryIndex], recentHistoryIndex: recentSearchHistoryIndex)
                 }
@@ -34,7 +34,7 @@ struct RecentSearchHistoryListTitleView: View {
             Text("최근 검색어")
                 .font(.system(size: 18).bold())
             Spacer()
-            if searchStates._searchHistorys != [] {
+            if !searchStates._searchHistorys.isEmpty {
                 Button {
                     searchStates.resetSearchHistorys()
                 } label: {
@@ -68,7 +68,6 @@ struct RecentSearchHistoryCell: View {
     var body: some View {
         VStack(spacing: .zero) {
             //TODO: Divider 공통 컴포넌트로 변경 예정
-            //Divider()
             HStack(alignment:.center, spacing: .zero) {
                 Text(recentHistory)
                     .font(.callout)

--- a/Module-MeetUP/Module-MeetUP/Screens/Search/SearchViewComponents/RecentSearchHistoryListView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/Search/SearchViewComponents/RecentSearchHistoryListView.swift
@@ -12,8 +12,13 @@ struct RecentSearchHistoryListView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: .zero) {
             RecentSearchHistoryListTitleView(searchStates: searchStates)
-            ForEach(searchStates.searchHistorys, id: \.self) { recentSearchHistory in
-                RecentSearchHistoryCellView(recentHistory: recentSearchHistory)
+            if searchStates._searchHistorys != [] {
+                ForEach(searchStates.searchHistorys, id: \.self) { recentSearchHistory in
+                    RecentSearchHistoryCell(recentHistory: recentSearchHistory)
+                }
+            }
+            else {
+                NoneRecentSearchHistorysView()
             }
             Spacer()
         }
@@ -42,14 +47,25 @@ struct RecentSearchHistoryListTitleView: View {
     }
 }
 
-struct RecentSearchHistoryCellView: View {
+struct NoneRecentSearchHistorysView: View {
+    var body: some View {
+        VStack(spacing:. zero) {
+            Divider()
+                .padding(EdgeInsets(top: 7, leading: 20, bottom: 23, trailing: 20))
+            Text("최근 검색 항목이 존재하지 않습니다.")
+                .font(.callout)
+        }
+    }
+}
+
+struct RecentSearchHistoryCell: View {
     
     let recentHistory: String
     
     var body: some View {
         VStack(spacing: .zero) {
             //TODO: Divider 공통 컴포넌트로 변경 예정
-            Divider()
+            //Divider()
             HStack(alignment:.center, spacing: .zero) {
                 Text(recentHistory)
                     .font(.callout)

--- a/Module-MeetUP/Module-MeetUP/Screens/Search/SearchViewComponents/RecentSearchHistoryListView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/Search/SearchViewComponents/RecentSearchHistoryListView.swift
@@ -13,8 +13,8 @@ struct RecentSearchHistoryListView: View {
         VStack(alignment: .leading, spacing: .zero) {
             RecentSearchHistoryListTitleView(searchStates: searchStates)
             if searchStates._searchHistorys != [] {
-                ForEach(searchStates.searchHistorys, id: \.self) { recentSearchHistory in
-                    RecentSearchHistoryCell(recentHistory: recentSearchHistory)
+                ForEach(0 ..< searchStates.searchHistorys.count, id: \.self) { recentSearchHistoryIndex in
+                    RecentSearchHistoryCell(searchStates: searchStates, recentHistory: searchStates.searchHistorys[recentSearchHistoryIndex], recentHistoryIndex: recentSearchHistoryIndex)
                 }
             }
             else {
@@ -34,13 +34,14 @@ struct RecentSearchHistoryListTitleView: View {
             Text("최근 검색어")
                 .font(.system(size: 18).bold())
             Spacer()
-            //TODO: 분기처리 필요
-            Button {
-                searchStates.resetSearchHistorys()
-            } label: {
-                Text("전체 삭제")
-                    .font(.callout)
-                    .foregroundColor(.gray)
+            if searchStates._searchHistorys != [] {
+                Button {
+                    searchStates.resetSearchHistorys()
+                } label: {
+                    Text("전체 삭제")
+                        .font(.callout)
+                        .foregroundColor(.gray)
+                }
             }
         }
         .padding(EdgeInsets(top: .zero, leading: 20, bottom: 10, trailing: 20))
@@ -60,7 +61,9 @@ struct NoneRecentSearchHistorysView: View {
 
 struct RecentSearchHistoryCell: View {
     
+    @StateObject var searchStates: SearchStateHolder
     let recentHistory: String
+    let recentHistoryIndex: Int
     
     var body: some View {
         VStack(spacing: .zero) {
@@ -72,13 +75,12 @@ struct RecentSearchHistoryCell: View {
                     .foregroundColor(.black)
                 Spacer()
                 Button {
-                    //TODO: 최근 검색어 삭제
+                    searchStates._searchHistorys.remove(at: recentHistoryIndex)
                 } label: {
                     Image(systemName: "xmark")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 17)
-                        //.fontWeight(.light)
                         .foregroundColor(.gray)
                 }
 


### PR DESCRIPTION
### Motivation 🥳 (코드를 추가/변경하게 된 이유)
- SearchView 의 최근 검색어 삭제 로직 구현


### Key Changes 🔥 (주요 구현/변경 사항)
- SearchView 최근 검색어 삭제 구현
- SearchView 최근 검색어 전체 삭제 구현
- 전체 삭제 또는 최근 검색어가 없을 시 다른 뷰가 나오도록 분기처리
- 키보드 올라오면서 삭제 버튼이 작아지는 이슈 ignoreSafeArea(.keyboard) 로 해결


### ScreenShot 📷 (참고 사진)
![Simulator Screen Recording - iPhone 13 Pro - 2022-10-16 at 15 28 51](https://user-images.githubusercontent.com/103012087/196021589-c4349c0c-f718-41de-978e-fc5075262e97.gif)



### ToDo 📆 (남은 작업)
- [ ] 최근 검색어 배치 순서 변경
- [ ] SearchBar UI 수정
- [ ] 검색어 아무것도 없을 시 검색 버튼 안눌리도록 처리
- [ ] 키보드 부분 처리


### Close Issues 🔒 (닫을 Issue)
Close #24 


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 최근 검색어 낱개 삭제를 구현하면서 ForEach문이 조금 더러워진 것 같은데 더 나은 방법이 있다면 리뷰 부탁드립니다!
- 최근 검색어 낱개 삭제 로직을 딱히 함수로 만들 필요 없을 것 같아서 바로 Button Action 안에 구현했는데 함수로 만드는 게 낫거나 다른 방법이 있다면 리뷰 부탁드려요!

