### PR TITLE
키보드 비활성화, 오토포커싱

### DIFF
--- a/Module-MeetUP/Module-MeetUP.xcodeproj/project.pbxproj
+++ b/Module-MeetUP/Module-MeetUP.xcodeproj/project.pbxproj
@@ -495,6 +495,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -524,6 +525,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Module-MeetUP/Module-MeetUP/Global/Extension/ViewExtension.swift
+++ b/Module-MeetUP/Module-MeetUP/Global/Extension/ViewExtension.swift
@@ -18,3 +18,9 @@ extension UINavigationController: ObservableObject, UIGestureRecognizerDelegate 
         return viewControllers.count > 1
     }
 }
+
+extension View {
+  func hideKeyboard() {
+    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+  }
+}

--- a/Module-MeetUP/Module-MeetUP/Screens/Search/SearchView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/Search/SearchView.swift
@@ -15,7 +15,11 @@ struct SearchView: View {
             RecentSearchHistoryListView(searchStates: searchStates)
             Spacer()
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .ignoresSafeArea(.keyboard)
+        .onTapGesture {
+            hideKeyboard()
+        }
     }
 }
 

--- a/Module-MeetUP/Module-MeetUP/Screens/Search/SearchViewComponents/SearchBarView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/Search/SearchViewComponents/SearchBarView.swift
@@ -14,6 +14,7 @@ struct SearchBarView: View {
         HStack(spacing: .zero){
             Button {
                 searchStates.updateSearchContent()
+                hideKeyboard()
             } label: {
                 Image(systemName: "magnifyingglass")
                     .resizable()

--- a/Module-MeetUP/Module-MeetUP/Screens/Search/SearchViewComponents/SearchBarView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/Search/SearchViewComponents/SearchBarView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SearchBarView: View {
     //TODO: 임시 텍스트필드 변수 변경 예정
+    @available(iOS 15, *) @FocusState private var focus: Bool
     @StateObject var searchStates: SearchStateHolder
     var body: some View {
         HStack(spacing: .zero){
@@ -25,6 +26,12 @@ struct SearchBarView: View {
             .padding(.trailing, 9)
             TextField("찾고싶은 제목, 내용을 입력해주세요", text: $searchStates.searchContent)
                 .font(.callout)
+                .focused($focus)
+                .onAppear {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                        self.focus = true
+                    }
+                }
             Spacer()
             Button {
                 searchStates.searchContent = ""


### PR DESCRIPTION
### Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 빈 영역 터치 시 키보드 비활성화
- 검색 버튼 터치 시 키보드 비활성화
- 키보드 오토포커싱


### Key Changes 🔥 (주요 구현/변경 사항)
- UIKit resignFirstResponder 메소드를 ViewExtension 에서 활용하여 비활성화 메서드 구현
- 키보드 오토 포커싱


### ScreenShot 📷 (참고 사진)
https://user-images.githubusercontent.com/103012087/196701408-9bc9bca5-794c-480d-9b27-b62cca790eba.MP4



### ToDo 📆 (남은 작업)
- [ ] TextField 비었을때 검색버튼 비활성화


### Reference 🔗
https://stackoverflow.com/questions/60348988/swiftui-dismissing-keyboard-on-tapping-anywhere-in-the-view-issues-with-othe


### Close Issues 🔒 (닫을 Issue)
Close #30 


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 기존 아담 앱과 동일하게 오토포커싱까지 걸리는 시간은 1초로 설정했습니다!
혹시 길거나 짧다면 리뷰 부탁드려요

