### PR TITLE
DateFormat를 추가합니다.

### DIFF
--- a/Module-MeetUP/Module-MeetUP.xcodeproj/project.pbxproj
+++ b/Module-MeetUP/Module-MeetUP.xcodeproj/project.pbxproj
@@ -8,9 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		2A48679328D746BA0011FE44 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A48679228D746BA0011FE44 /* ViewExtension.swift */; };
+		2A49A1272927EBE200897379 /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A1262927EBE200897379 /* DateExtension.swift */; };
+		2A71017B28EAD8E1001049B1 /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A71017A28EAD8E1001049B1 /* ArrayExtension.swift */; };
 		2A71017D28F158AF001049B1 /* WriteButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A71017C28F158AF001049B1 /* WriteButtonView.swift */; };
 		2A71017F28F16552001049B1 /* PostsListSearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A71017E28F16552001049B1 /* PostsListSearchBarView.swift */; };
-		2A71017B28EAD8E1001049B1 /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A71017A28EAD8E1001049B1 /* ArrayExtension.swift */; };
 		2ABA33D028D967FC00A16804 /* RecentSearchHistoryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ABA33CF28D967FC00A16804 /* RecentSearchHistoryListView.swift */; };
 		2ABDC53C28D96D8900A3D1E6 /* SearchBackButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ABDC53B28D96D8900A3D1E6 /* SearchBackButtonView.swift */; };
 		2ABDC53E28D96E9400A3D1E6 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ABDC53D28D96E9400A3D1E6 /* SearchView.swift */; };
@@ -42,9 +43,10 @@
 
 /* Begin PBXFileReference section */
 		2A48679228D746BA0011FE44 /* ViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtension.swift; sourceTree = "<group>"; };
+		2A49A1262927EBE200897379 /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
+		2A71017A28EAD8E1001049B1 /* ArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
 		2A71017C28F158AF001049B1 /* WriteButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteButtonView.swift; sourceTree = "<group>"; };
 		2A71017E28F16552001049B1 /* PostsListSearchBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostsListSearchBarView.swift; sourceTree = "<group>"; };
-		2A71017A28EAD8E1001049B1 /* ArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
 		2ABA33CF28D967FC00A16804 /* RecentSearchHistoryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearchHistoryListView.swift; sourceTree = "<group>"; };
 		2ABDC53B28D96D8900A3D1E6 /* SearchBackButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBackButtonView.swift; sourceTree = "<group>"; };
 		2ABDC53D28D96E9400A3D1E6 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
@@ -91,6 +93,7 @@
 			children = (
 				2A48679228D746BA0011FE44 /* ViewExtension.swift */,
 				2A71017A28EAD8E1001049B1 /* ArrayExtension.swift */,
+				2A49A1262927EBE200897379 /* DateExtension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -331,6 +334,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AB009FB128D8C5E000A43D63 /* PostDetailTitleArea.swift in Sources */,
+				2A49A1272927EBE200897379 /* DateExtension.swift in Sources */,
 				2A71017F28F16552001049B1 /* PostsListSearchBarView.swift in Sources */,
 				AB009FB728D8C64300A43D63 /* Post.swift in Sources */,
 				2ABDC53C28D96D8900A3D1E6 /* SearchBackButtonView.swift in Sources */,
@@ -347,7 +351,6 @@
 				2ABA33D028D967FC00A16804 /* RecentSearchHistoryListView.swift in Sources */,
 				2A71017D28F158AF001049B1 /* WriteButtonView.swift in Sources */,
 				2A71017B28EAD8E1001049B1 /* ArrayExtension.swift in Sources */,
-				AB009F6D28D7929900A43D63 /* SearchButton.swift in Sources */,
 				AB009FB228D8C5E000A43D63 /* PostDetailView.swift in Sources */,
 				AB009FA528D8C5CE00A43D63 /* MainView.swift in Sources */,
 				AB009FAD28D8C5E000A43D63 /* PostDetailStateHolder.swift in Sources */,
@@ -355,7 +358,6 @@
 				AB009FB428D8C61A00A43D63 /* DeviceInfo.swift in Sources */,
 				AB009F6728D7929900A43D63 /* PostsListView.swift in Sources */,
 				ABD4875B28D6FAD300FFD3A1 /* JsonDecodertemp.swift in Sources */,
-				AB009F6C28D7929900A43D63 /* FloatingButtonView.swift in Sources */,
 				2ACDB26228DA8BEB0016E117 /* SearchStateHolder.swift in Sources */,
 				AB009F6B28D7929900A43D63 /* BackButtonView.swift in Sources */,
 				2ABDC54028D9A19F00A3D1E6 /* SearchViewTitle.swift in Sources */,

--- a/Module-MeetUP/Module-MeetUP/Global/Extension/DateExtension.swift
+++ b/Module-MeetUP/Module-MeetUP/Global/Extension/DateExtension.swift
@@ -8,6 +8,20 @@
 import Foundation
 
 extension Date {
+    func getDate() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy.MM.dd"
+        dateFormatter.locale = Locale(identifier: "ko")
+        return dateFormatter.string(from: self).capitalized
+    }
+    
+    func getMonthAndDayKor() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MM월 dd일"
+        dateFormatter.locale = Locale(identifier: "ko")
+        return dateFormatter.string(from: self).capitalized
+    }
+    
     func getDayOfWeekShort() -> String {
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "E"
@@ -18,6 +32,13 @@ extension Date {
     func getDayOfWeek() -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "EEEE"
+        dateFormatter.locale = Locale(identifier: "ko")
+        return dateFormatter.string(from: self).capitalized
+    }
+    
+    func getMonthAndDay() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MM.dd"
         dateFormatter.locale = Locale(identifier: "ko")
         return dateFormatter.string(from: self).capitalized
     }

--- a/Module-MeetUP/Module-MeetUP/Global/Extension/DateExtension.swift
+++ b/Module-MeetUP/Module-MeetUP/Global/Extension/DateExtension.swift
@@ -1,0 +1,24 @@
+//
+//  DateExtension.swift
+//  Module-MeetUP
+//
+//  Created by 한택환 on 2022/11/19.
+//
+
+import Foundation
+
+extension Date {
+    func getDayOfWeekShort() -> String {
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "E"
+            dateFormatter.locale = Locale(identifier: "ko")
+            return dateFormatter.string(from: self).capitalized
+        }
+    
+    func getDayOfWeek() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "EEEE"
+        dateFormatter.locale = Locale(identifier: "ko")
+        return dateFormatter.string(from: self).capitalized
+    }
+}


### PR DESCRIPTION
### Motivation 🥳 (코드를 추가/변경하게 된 이유)
여러 View 에서 다양하게 사용되는 날짜 형식을 Extension으로 추가합니다.


### Key Changes 🔥 (주요 구현/변경 사항)
DateExtension.swift 파일을 생성 후 extension 내에서 날짜 형식에 따른 메서드를 각각 구현하였습니다.
```swift
    func getDate() -> String {
        let dateFormatter = DateFormatter()
        dateFormatter.dateFormat = "yyyy.MM.dd"
        dateFormatter.locale = Locale(identifier: "ko")
        return dateFormatter.string(from: self).capitalized
    }
```



### Close Issues 🔒 (닫을 Issue)
Close #35 


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 필요 시 시간 형식, 날짜 형식 모두 추가하시면서 사용하면 될 것 같습니다.
- 날짜 형식의 양이 많아 최대한 중복을 피하고자 #34 에 형식에 따른 메서드명을 정리해두면 좋을 것 같습니다!
- 메서드를 구현하는 것 말고 날짜 형식을 사용하는 것에 있어 더 나은 방식이 있다면 리뷰 부탁드립니다.
