### PR TITLE
포스텍식단뷰의 캘린더, 타이틀, 세그먼트 피커를 구현합니다.

### DIFF
--- a/Module-MeetUP/Module-MeetUP.xcodeproj/project.pbxproj
+++ b/Module-MeetUP/Module-MeetUP.xcodeproj/project.pbxproj
@@ -8,9 +8,16 @@
 
 /* Begin PBXBuildFile section */
 		2A48679328D746BA0011FE44 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A48679228D746BA0011FE44 /* ViewExtension.swift */; };
+		2A49A1172927DFBA00897379 /* PostechMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A1162927DFBA00897379 /* PostechMenuView.swift */; };
+		2A49A11A2927E02000897379 /* RestaurantSegmentedPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A1192927E02000897379 /* RestaurantSegmentedPickerView.swift */; };
+		2A49A11C2927E03800897379 /* MenuWeeklyCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A11B2927E03800897379 /* MenuWeeklyCalendarView.swift */; };
+		2A49A11E2927E05300897379 /* PostechMenuTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A11D2927E05300897379 /* PostechMenuTitleView.swift */; };
+		2A49A1212927E0A900897379 /* JigokMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A1202927E0A900897379 /* JigokMenuView.swift */; };
+		2A49A1232927E0B300897379 /* WisdomMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A1222927E0B300897379 /* WisdomMenuView.swift */; };
+		2A49A1252927E0CB00897379 /* BluehillMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A1242927E0CB00897379 /* BluehillMenuView.swift */; };
+		2A71017B28EAD8E1001049B1 /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A71017A28EAD8E1001049B1 /* ArrayExtension.swift */; };
 		2A71017D28F158AF001049B1 /* WriteButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A71017C28F158AF001049B1 /* WriteButtonView.swift */; };
 		2A71017F28F16552001049B1 /* PostsListSearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A71017E28F16552001049B1 /* PostsListSearchBarView.swift */; };
-		2A71017B28EAD8E1001049B1 /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A71017A28EAD8E1001049B1 /* ArrayExtension.swift */; };
 		2ABA33D028D967FC00A16804 /* RecentSearchHistoryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ABA33CF28D967FC00A16804 /* RecentSearchHistoryListView.swift */; };
 		2ABDC53C28D96D8900A3D1E6 /* SearchBackButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ABDC53B28D96D8900A3D1E6 /* SearchBackButtonView.swift */; };
 		2ABDC53E28D96E9400A3D1E6 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ABDC53D28D96E9400A3D1E6 /* SearchView.swift */; };
@@ -42,9 +49,16 @@
 
 /* Begin PBXFileReference section */
 		2A48679228D746BA0011FE44 /* ViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtension.swift; sourceTree = "<group>"; };
+		2A49A1162927DFBA00897379 /* PostechMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostechMenuView.swift; sourceTree = "<group>"; };
+		2A49A1192927E02000897379 /* RestaurantSegmentedPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestaurantSegmentedPickerView.swift; sourceTree = "<group>"; };
+		2A49A11B2927E03800897379 /* MenuWeeklyCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuWeeklyCalendarView.swift; sourceTree = "<group>"; };
+		2A49A11D2927E05300897379 /* PostechMenuTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostechMenuTitleView.swift; sourceTree = "<group>"; };
+		2A49A1202927E0A900897379 /* JigokMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JigokMenuView.swift; sourceTree = "<group>"; };
+		2A49A1222927E0B300897379 /* WisdomMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WisdomMenuView.swift; sourceTree = "<group>"; };
+		2A49A1242927E0CB00897379 /* BluehillMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluehillMenuView.swift; sourceTree = "<group>"; };
+		2A71017A28EAD8E1001049B1 /* ArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
 		2A71017C28F158AF001049B1 /* WriteButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteButtonView.swift; sourceTree = "<group>"; };
 		2A71017E28F16552001049B1 /* PostsListSearchBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostsListSearchBarView.swift; sourceTree = "<group>"; };
-		2A71017A28EAD8E1001049B1 /* ArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
 		2ABA33CF28D967FC00A16804 /* RecentSearchHistoryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearchHistoryListView.swift; sourceTree = "<group>"; };
 		2ABDC53B28D96D8900A3D1E6 /* SearchBackButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBackButtonView.swift; sourceTree = "<group>"; };
 		2ABDC53D28D96E9400A3D1E6 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
@@ -93,6 +107,36 @@
 				2A71017A28EAD8E1001049B1 /* ArrayExtension.swift */,
 			);
 			path = Extension;
+			sourceTree = "<group>";
+		};
+		2A49A1152927DFA400897379 /* PostechMenuView */ = {
+			isa = PBXGroup;
+			children = (
+				2A49A1182927DFBE00897379 /* ViewComponents */,
+				2A49A1162927DFBA00897379 /* PostechMenuView.swift */,
+			);
+			path = PostechMenuView;
+			sourceTree = "<group>";
+		};
+		2A49A1182927DFBE00897379 /* ViewComponents */ = {
+			isa = PBXGroup;
+			children = (
+				2A49A11F2927E05700897379 /* RestaurantsViewComponents */,
+				2A49A1192927E02000897379 /* RestaurantSegmentedPickerView.swift */,
+				2A49A11B2927E03800897379 /* MenuWeeklyCalendarView.swift */,
+				2A49A11D2927E05300897379 /* PostechMenuTitleView.swift */,
+			);
+			path = ViewComponents;
+			sourceTree = "<group>";
+		};
+		2A49A11F2927E05700897379 /* RestaurantsViewComponents */ = {
+			isa = PBXGroup;
+			children = (
+				2A49A1202927E0A900897379 /* JigokMenuView.swift */,
+				2A49A1222927E0B300897379 /* WisdomMenuView.swift */,
+				2A49A1242927E0CB00897379 /* BluehillMenuView.swift */,
+			);
+			path = RestaurantsViewComponents;
 			sourceTree = "<group>";
 		};
 		2AC77E8A28D943B70038514F /* Search */ = {
@@ -210,6 +254,7 @@
 		ABD4875528D6FA4400FFD3A1 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				2A49A1152927DFA400897379 /* PostechMenuView */,
 				AB009FA428D8C5CE00A43D63 /* MainView.swift */,
 				ABD4874F28D6F9B400FFD3A1 /* PostsListView */,
 				ABD4875228D6FA0600FFD3A1 /* PostDetailView */,
@@ -336,6 +381,8 @@
 				2ABDC53C28D96D8900A3D1E6 /* SearchBackButtonView.swift in Sources */,
 				AB009FA228D8C5B500A43D63 /* MeetUpNetworkService.swift in Sources */,
 				AB009F6928D7929900A43D63 /* PostCell.swift in Sources */,
+				2A49A11E2927E05300897379 /* PostechMenuTitleView.swift in Sources */,
+				2A49A11A2927E02000897379 /* RestaurantSegmentedPickerView.swift in Sources */,
 				AB009F6A28D7929900A43D63 /* PostsListTitleView.swift in Sources */,
 				ABD4874228D6F99500FFD3A1 /* Module_MeetUPApp.swift in Sources */,
 				2AC77E8D28D943FF0038514F /* SearchBarView.swift in Sources */,
@@ -346,18 +393,21 @@
 				AB009FAF28D8C5E000A43D63 /* PostDetailInfoArea.swift in Sources */,
 				2ABA33D028D967FC00A16804 /* RecentSearchHistoryListView.swift in Sources */,
 				2A71017D28F158AF001049B1 /* WriteButtonView.swift in Sources */,
+				2A49A1212927E0A900897379 /* JigokMenuView.swift in Sources */,
 				2A71017B28EAD8E1001049B1 /* ArrayExtension.swift in Sources */,
-				AB009F6D28D7929900A43D63 /* SearchButton.swift in Sources */,
 				AB009FB228D8C5E000A43D63 /* PostDetailView.swift in Sources */,
+				2A49A11C2927E03800897379 /* MenuWeeklyCalendarView.swift in Sources */,
 				AB009FA528D8C5CE00A43D63 /* MainView.swift in Sources */,
 				AB009FAD28D8C5E000A43D63 /* PostDetailStateHolder.swift in Sources */,
 				2A48679328D746BA0011FE44 /* ViewExtension.swift in Sources */,
 				AB009FB428D8C61A00A43D63 /* DeviceInfo.swift in Sources */,
+				2A49A1252927E0CB00897379 /* BluehillMenuView.swift in Sources */,
 				AB009F6728D7929900A43D63 /* PostsListView.swift in Sources */,
 				ABD4875B28D6FAD300FFD3A1 /* JsonDecodertemp.swift in Sources */,
-				AB009F6C28D7929900A43D63 /* FloatingButtonView.swift in Sources */,
+				2A49A1172927DFBA00897379 /* PostechMenuView.swift in Sources */,
 				2ACDB26228DA8BEB0016E117 /* SearchStateHolder.swift in Sources */,
 				AB009F6B28D7929900A43D63 /* BackButtonView.swift in Sources */,
+				2A49A1232927E0B300897379 /* WisdomMenuView.swift in Sources */,
 				2ABDC54028D9A19F00A3D1E6 /* SearchViewTitle.swift in Sources */,
 				2AC77E8628D873710038514F /* RefreshableScrollView.swift in Sources */,
 				AB009FB028D8C5E000A43D63 /* PostDetailBodyArea.swift in Sources */,

--- a/Module-MeetUP/Module-MeetUP/Global/Extension/DateExtension.swift
+++ b/Module-MeetUP/Module-MeetUP/Global/Extension/DateExtension.swift
@@ -42,4 +42,11 @@ extension Date {
         dateFormatter.locale = Locale(identifier: "ko")
         return dateFormatter.string(from: self).capitalized
     }
+    
+    func getDay() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "dd"
+        dateFormatter.locale = Locale(identifier: "ko")
+        return dateFormatter.string(from: self).capitalized
+    }
 }

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/PostechMenuView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/PostechMenuView.swift
@@ -13,12 +13,13 @@ struct PostechMenuView: View {
     
     var body: some View {
         VStack(spacing: .zero) {
-            PostechMenuTitleView(selectedDate: $selectedDate)
+            PostechMenuTitleView(selectedRestaurantNum: $selectedRestaurantNum, selectedDate: $selectedDate)
                 .padding(.bottom, 18)
             MenuWeeklyCalendarView(selectedDate: $selectedDate)
                 .padding(.bottom, 18)
+            //TODO: 식단뷰 들어갈 공간
             Spacer()
-            RestaurantSegmentedPickerView()
+            RestaurantSegmentedPickerView(selectedRestaurantNum: $selectedRestaurantNum)
             
         }
     }

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/PostechMenuView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/PostechMenuView.swift
@@ -8,8 +8,19 @@
 import SwiftUI
 
 struct PostechMenuView: View {
+    @State var selectedRestaurantNum = 0
+    @State var selectedDate = Date()
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack(spacing: .zero) {
+            PostechMenuTitleView(selectedDate: $selectedDate)
+                .padding(.bottom, 18)
+            MenuWeeklyCalendarView(selectedDate: $selectedDate)
+                .padding(.bottom, 18)
+            Spacer()
+            RestaurantSegmentedPickerView()
+            
+        }
     }
 }
 

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/PostechMenuView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/PostechMenuView.swift
@@ -1,0 +1,20 @@
+//
+//  PostechMenuView.swift
+//  Module-MeetUP
+//
+//  Created by 한택환 on 2022/11/19.
+//
+
+import SwiftUI
+
+struct PostechMenuView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct PostechMenuView_Previews: PreviewProvider {
+    static var previews: some View {
+        PostechMenuView()
+    }
+}

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/MenuWeeklyCalendarView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/MenuWeeklyCalendarView.swift
@@ -15,6 +15,6 @@ struct MenuWeeklyCalendarView: View {
 
 struct MenuWeeklyCalendarView_Previews: PreviewProvider {
     static var previews: some View {
-        MenuWeeklyCalendar()
+        MenuWeeklyCalendarView()
     }
 }

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/MenuWeeklyCalendarView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/MenuWeeklyCalendarView.swift
@@ -24,17 +24,17 @@ struct MenuWeeklyCalendarView: View {
                         } label: {
                             //TODO: DateFormatter 추가 후 전체 텍스트 변경 필요
                             VStack(spacing: 4) {
-                                Text("일")
+                                Text("\(date.getDayOfWeekShort())")
                                     .font(.system(size: 16))
                                     .fontWeight(.semibold)
-                                    .foregroundColor(date == Date() ? .blue : .black)
-                                Text("22")
+                                    .foregroundColor(date.getDate() == Date().getDate() ? .blue : .black)
+                                Text("\(date.getDay())")
                                     .font(.system(size: 12))
                                     .fontWeight(.bold)
-                                    .foregroundColor(date == Date() ? .blue : .gray)
+                                    .foregroundColor(date.getDate() == Date().getDate() ? .blue : .gray)
                             }
                             .padding(8)
-                            .background(Capsule().strokeBorder(date == Date() ?  .blue : .clear))
+                            .background(Capsule().strokeBorder(date.getDate() == Date().getDate() ?  .blue : .clear))
                         }
                     }
                     .frame(width: (UIScreen.main.bounds.width - 40) / 7)

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/MenuWeeklyCalendarView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/MenuWeeklyCalendarView.swift
@@ -1,0 +1,20 @@
+//
+//  MenuWeeklyCalendar.swift
+//  Module-MeetUP
+//
+//  Created by 한택환 on 2022/11/19.
+//
+
+import SwiftUI
+
+struct MenuWeeklyCalendarView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct MenuWeeklyCalendarView_Previews: PreviewProvider {
+    static var previews: some View {
+        MenuWeeklyCalendar()
+    }
+}

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/MenuWeeklyCalendarView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/MenuWeeklyCalendarView.swift
@@ -16,9 +16,29 @@ struct MenuWeeklyCalendarView: View {
         }
         return dateRange
     }
-    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+                HStack(alignment: .center, spacing: .zero) {
+                    ForEach(getDateRange(), id: \.self) { date in
+                        Button {
+                            //TODO: 선택날짜 전달
+                        } label: {
+                            //TODO: DateFormatter 추가 후 전체 텍스트 변경 필요
+                            VStack(spacing: 4) {
+                                Text("일")
+                                    .font(.system(size: 16))
+                                    .fontWeight(.semibold)
+                                    .foregroundColor(date == Date() ? .blue : .black)
+                                Text("22")
+                                    .font(.system(size: 12))
+                                    .fontWeight(.bold)
+                                    .foregroundColor(date == Date() ? .blue : .gray)
+                            }
+                            .padding(8)
+                            .background(Capsule().strokeBorder(date == Date() ?  .blue : .clear))
+                        }
+                    }
+                    .frame(width: (UIScreen.main.bounds.width - 40) / 7)
+        }
     }
 }
 

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/MenuWeeklyCalendarView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/MenuWeeklyCalendarView.swift
@@ -24,14 +24,14 @@ struct MenuWeeklyCalendarView: View {
                         } label: {
                             //TODO: DateFormatter 추가 후 전체 텍스트 변경 필요
                             VStack(spacing: 4) {
+                                Text("\(date.getDay())")
+                                    .font(.system(size: 12))
+                                    .fontWeight(date.getDate() == Date().getDate() ? .bold : .semibold)
+                                    .foregroundColor(date.getDate() == Date().getDate() ? .blue : .gray)
                                 Text("\(date.getDayOfWeekShort())")
                                     .font(.system(size: 16))
                                     .fontWeight(.semibold)
                                     .foregroundColor(date.getDate() == Date().getDate() ? .blue : .black)
-                                Text("\(date.getDay())")
-                                    .font(.system(size: 12))
-                                    .fontWeight(.bold)
-                                    .foregroundColor(date.getDate() == Date().getDate() ? .blue : .gray)
                             }
                             .padding(8)
                             .background(Capsule().strokeBorder(date.getDate() == Date().getDate() ?  .blue : .clear))

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/MenuWeeklyCalendarView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/MenuWeeklyCalendarView.swift
@@ -16,11 +16,13 @@ struct MenuWeeklyCalendarView: View {
         }
         return dateRange
     }
+    //TODO: 후에 PostechMenuStateHolder의 변수로 교체 예정
+    @State var selectedDate = Date()
     var body: some View {
                 HStack(alignment: .center, spacing: .zero) {
                     ForEach(getDateRange(), id: \.self) { date in
                         Button {
-                            //TODO: 선택날짜 전달
+                            selectedDate = date
                         } label: {
                             //TODO: DateFormatter 추가 후 전체 텍스트 변경 필요
                             VStack(spacing: 4) {
@@ -34,10 +36,10 @@ struct MenuWeeklyCalendarView: View {
                                     .foregroundColor(date.getDate() == Date().getDate() ? .blue : .black)
                             }
                             .padding(8)
-                            .background(Capsule().strokeBorder(date.getDate() == Date().getDate() ?  .blue : .clear))
+                            .background(Capsule().strokeBorder(date.getDate() == selectedDate.getDate() ?  .blue : .clear))
                         }
                     }
-                    .frame(width: (UIScreen.main.bounds.width - 40) / 7)
+                    .frame(width: (UIScreen.main.bounds.width - 46) / 7)
         }
     }
 }

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/MenuWeeklyCalendarView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/MenuWeeklyCalendarView.swift
@@ -8,6 +8,15 @@
 import SwiftUI
 
 struct MenuWeeklyCalendarView: View {
+    //TODO: 후에 PostechMenuStateHolder.swift로 옮길 로직
+    func getDateRange() -> [Date] {
+        var dateRange: [Date] = []
+        for addDate in 0..<7 {
+            dateRange.append(Calendar.current.date(byAdding: .day, value: addDate, to: Date()) ?? Date())
+        }
+        return dateRange
+    }
+    
     var body: some View {
         Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
     }

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/MenuWeeklyCalendarView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/MenuWeeklyCalendarView.swift
@@ -17,7 +17,7 @@ struct MenuWeeklyCalendarView: View {
         return dateRange
     }
     //TODO: 후에 PostechMenuStateHolder의 변수로 교체 예정
-    @State var selectedDate = Date()
+    @Binding var selectedDate: Date
     var body: some View {
                 HStack(alignment: .center, spacing: .zero) {
                     ForEach(getDateRange(), id: \.self) { date in
@@ -46,6 +46,6 @@ struct MenuWeeklyCalendarView: View {
 
 struct MenuWeeklyCalendarView_Previews: PreviewProvider {
     static var previews: some View {
-        MenuWeeklyCalendarView()
+        MenuWeeklyCalendarView(selectedDate: .constant(Date()))
     }
 }

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/MenuWeeklyCalendarView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/MenuWeeklyCalendarView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MenuWeeklyCalendarView: View {
-    //TODO: 후에 PostechMenuStateHolder.swift로 옮길 로직
+    //TODO: 후에 PostechMenuStateHolder로 옮길 로직
     func getDateRange() -> [Date] {
         var dateRange: [Date] = []
         for addDate in 0..<7 {
@@ -24,7 +24,6 @@ struct MenuWeeklyCalendarView: View {
                         Button {
                             selectedDate = date
                         } label: {
-                            //TODO: DateFormatter 추가 후 전체 텍스트 변경 필요
                             VStack(spacing: 4) {
                                 Text("\(date.getDay())")
                                     .font(.system(size: 12))

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/PostechMenuTitleView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/PostechMenuTitleView.swift
@@ -8,8 +8,30 @@
 import SwiftUI
 
 struct PostechMenuTitleView: View {
+    var selectedRestaurantIndex: Int = 0
+    var selectedDate: String = "0월0일 일요일"
+    
+    func setRestaurantTitle() -> String {
+        switch selectedRestaurantIndex {
+        case 0:
+            return "지곡회관"
+        case 1:
+            return "위즈덤"
+        case 2:
+            return "블루힐"
+        default:
+            return "지곡회관"
+        }
+    }
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        Text("\(setRestaurantTitle()) \(selectedDate)")
+            .font(.callout)
+            .foregroundColor(.black)
+            .padding(EdgeInsets(top: 11, leading: 68, bottom: 10, trailing: 69))
+            .background(RoundedRectangle(cornerRadius: 50)
+                .foregroundColor(.black)
+                .opacity(0.05))
     }
 }
 

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/PostechMenuTitleView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/PostechMenuTitleView.swift
@@ -1,0 +1,20 @@
+//
+//  PostechMenuTitleView.swift
+//  Module-MeetUP
+//
+//  Created by 한택환 on 2022/11/19.
+//
+
+import SwiftUI
+
+struct PostechMenuTitleView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct PostechMenuTitleView_Previews: PreviewProvider {
+    static var previews: some View {
+        PostechMenuTitleView()
+    }
+}

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/PostechMenuTitleView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/PostechMenuTitleView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct PostechMenuTitleView: View {
     //TODO: 선택된 날짜 및 식당 인덱스 메인뷰에서의 바인딩 필요
     var selectedRestaurantIndex: Int = 0
-    var selectedDate: String = "0월0일 일요일"
+    @Binding var selectedDate: Date
     
     func setRestaurantTitle() -> String {
         switch selectedRestaurantIndex {
@@ -26,7 +26,7 @@ struct PostechMenuTitleView: View {
     }
     
     var body: some View {
-        Text("\(setRestaurantTitle()) \(selectedDate)")
+        Text("\(setRestaurantTitle()) \(selectedDate.getMonthAndDayKor()) \(selectedDate.getDayOfWeek())")
             .font(.callout)
             .foregroundColor(.black)
             .padding(EdgeInsets(top: 11, leading: 68, bottom: 10, trailing: 69))
@@ -38,6 +38,6 @@ struct PostechMenuTitleView: View {
 
 struct PostechMenuTitleView_Previews: PreviewProvider {
     static var previews: some View {
-        PostechMenuTitleView()
+        PostechMenuTitleView(selectedDate: .constant(Date()))
     }
 }

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/PostechMenuTitleView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/PostechMenuTitleView.swift
@@ -9,11 +9,11 @@ import SwiftUI
 
 struct PostechMenuTitleView: View {
     //TODO: 선택된 날짜 및 식당 인덱스 메인뷰에서의 바인딩 필요
-    var selectedRestaurantIndex: Int = 0
+    @Binding var selectedRestaurantNum: Int
     @Binding var selectedDate: Date
     
     func setRestaurantTitle() -> String {
-        switch selectedRestaurantIndex {
+        switch selectedRestaurantNum {
         case 0:
             return "지곡회관"
         case 1:
@@ -38,6 +38,6 @@ struct PostechMenuTitleView: View {
 
 struct PostechMenuTitleView_Previews: PreviewProvider {
     static var previews: some View {
-        PostechMenuTitleView(selectedDate: .constant(Date()))
+        PostechMenuTitleView(selectedRestaurantNum: .constant(0), selectedDate: .constant(Date()))
     }
 }

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/PostechMenuTitleView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/PostechMenuTitleView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct PostechMenuTitleView: View {
+    //TODO: 선택된 날짜 및 식당 인덱스 메인뷰에서의 바인딩 필요
     var selectedRestaurantIndex: Int = 0
     var selectedDate: String = "0월0일 일요일"
     

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/RestaurantSegmentedPickerView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/RestaurantSegmentedPickerView.swift
@@ -8,29 +8,29 @@
 import SwiftUI
 
 struct RestaurantSegmentedPickerView: View {
-    //TODO: 추후 PostechMenuView 에서 값 전달 예정
-    var selectedRestaurantIndex: Int = 0
+    //TODO: 추후 PostechMenuStateHolder 에서 값 전달 예정
+    @Binding var selectedRestaurantNum: Int
     let pickerIndex: [String] = ["지곡회관","위즈덤","블루힐"]
     
     var body: some View {
         HStack(spacing: .zero) {
-            ForEach(pickerIndex.indices, id:\.self) { restaurantIndex in
+            ForEach(pickerIndex.indices, id:\.self) { restaurantNum in
                 ZStack {
                     Rectangle()
                         .fill(.gray)
                     
                     RoundedRectangle(cornerRadius: 30)
                         .foregroundColor(.blue)
-                        .opacity(selectedRestaurantIndex == restaurantIndex ? 1 : 0.00001)
+                        .opacity(selectedRestaurantNum == restaurantNum ? 1 : 0.00001)
                         .onTapGesture {
-                            //TODO: PostechMenuView 의 값을 바꿔주면서 피커를 이동시킬 제스처
+                            selectedRestaurantNum = restaurantNum
                         }
                 }
                 .overlay(
-                    Text(pickerIndex[restaurantIndex])
+                    Text(pickerIndex[restaurantNum])
                         .font(.system(size: 16))
-                        .fontWeight(selectedRestaurantIndex == restaurantIndex ? .bold : .medium)
-                        .foregroundColor(selectedRestaurantIndex == restaurantIndex ? .white : .black)
+                        .fontWeight(selectedRestaurantNum == restaurantNum ? .bold : .medium)
+                        .foregroundColor(selectedRestaurantNum == restaurantNum ? .white : .black)
                 )
             }
             
@@ -43,6 +43,6 @@ struct RestaurantSegmentedPickerView: View {
 
 struct RestaurantSegmentedPickerView_Previews: PreviewProvider {
     static var previews: some View {
-        RestaurantSegmentedPickerView()
+        RestaurantSegmentedPickerView(selectedRestaurantNum: .constant(0))
     }
 }

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/RestaurantSegmentedPickerView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/RestaurantSegmentedPickerView.swift
@@ -8,8 +8,36 @@
 import SwiftUI
 
 struct RestaurantSegmentedPickerView: View {
+    //TODO: 추후 PostechMenuView 에서 값 전달 예정
+    var selectedRestaurantIndex: Int = 0
+    let pickerIndex: [String] = ["지곡회관","위즈덤","블루힐"]
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        HStack(spacing: .zero) {
+            ForEach(pickerIndex.indices, id:\.self) { restaurantIndex in
+                ZStack {
+                    Rectangle()
+                        .fill(.gray)
+                    
+                    RoundedRectangle(cornerRadius: 30)
+                        .foregroundColor(.blue)
+                        .opacity(selectedRestaurantIndex == restaurantIndex ? 1 : 0.00001)
+                        .onTapGesture {
+                            //TODO: PostechMenuView 의 값을 바꿔주면서 피커를 이동시킬 제스처
+                        }
+                }
+                .overlay(
+                    Text(pickerIndex[restaurantIndex])
+                        .font(.system(size: 16))
+                        .fontWeight(selectedRestaurantIndex == restaurantIndex ? .bold : .medium)
+                        .foregroundColor(selectedRestaurantIndex == restaurantIndex ? .white : .black)
+                )
+            }
+            
+        }
+        .frame(width: 298, height: 39)
+        .cornerRadius(30)
+        .shadow(color: .black, radius: 0.1, x: .zero, y: .zero)
     }
 }
 

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/RestaurantSegmentedPickerView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/RestaurantSegmentedPickerView.swift
@@ -1,0 +1,20 @@
+//
+//  RestaurantSegmentedPickerView.swift
+//  Module-MeetUP
+//
+//  Created by 한택환 on 2022/11/19.
+//
+
+import SwiftUI
+
+struct RestaurantSegmentedPickerView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct RestaurantSegmentedPickerView_Previews: PreviewProvider {
+    static var previews: some View {
+        RestaurantSegmentedPickerView()
+    }
+}

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/RestaurantsViewComponents/BluehillMenuView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/RestaurantsViewComponents/BluehillMenuView.swift
@@ -1,0 +1,20 @@
+//
+//  BluehillMenuView.swift
+//  Module-MeetUP
+//
+//  Created by 한택환 on 2022/11/19.
+//
+
+import SwiftUI
+
+struct BluehillMenuView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct BluehillMenuView_Previews: PreviewProvider {
+    static var previews: some View {
+        BluehillMenuView()
+    }
+}

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/RestaurantsViewComponents/JigokMenuView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/RestaurantsViewComponents/JigokMenuView.swift
@@ -1,0 +1,20 @@
+//
+//  JigokMenuView.swift
+//  Module-MeetUP
+//
+//  Created by 한택환 on 2022/11/19.
+//
+
+import SwiftUI
+
+struct JigokMenuView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct JigokMenuView_Previews: PreviewProvider {
+    static var previews: some View {
+        JigokMenuView()
+    }
+}

--- a/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/RestaurantsViewComponents/WisdomMenuView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostechMenuView/ViewComponents/RestaurantsViewComponents/WisdomMenuView.swift
@@ -1,0 +1,20 @@
+//
+//  WisdomMenuView.swift
+//  Module-MeetUP
+//
+//  Created by 한택환 on 2022/11/19.
+//
+
+import SwiftUI
+
+struct WisdomMenuView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct WisdomMenuView_Previews: PreviewProvider {
+    static var previews: some View {
+        WisdomMenuView()
+    }
+}


### PR DESCRIPTION
### Motivation 🥳 (코드를 추가/변경하게 된 이유)
포스텍 식단 UI 일부를 구현하였습니다.


### Key Changes 🔥 (주요 구현/변경 사항)
캘린더, 타이틀, 식당 선택 세그먼트 피커 UI 를 구현하였고 임시로 데이터 바인딩을 시켜두었습니다.

`WeeklyMenuCalendar` 에서 날짜 선택 시 발생하는 이벤트 UI 의 조건을 `.compare(_ other:)` 를 사용하여 비교하려고 했으나 작동하지 않아
`.foregroundColor(date.getDate() == Date().getDate() ? .blue : .gray)` 로 DateFormatter를 활용한 String 값으로 변경하여 비교하도록 하였습니다.


이후 데이터의 흐름은 아마 PostechStateHolder 가 추가되면 아래와 같이 구성될 것 같습니다.
<img width = 500 src="https://user-images.githubusercontent.com/103012087/202892783-277c0988-30f0-4b9d-89df-222190a1d01a.png">

`func getDateRange()`, `setRestaurantTitle()`  함수들은 아무래도 StateHolder 와는 큰 연관이 없다 판단되어 식단의 Model 파일에 들어갈 것 같습니다.
추후에 Model 구성도 첨부하겠습니다!


### ScreenShot 📷 (참고 사진)
![Simulator Screen Recording - iPhone 13 - 2022-11-20 at 17 38 38](https://user-images.githubusercontent.com/103012087/202893102-107aba6f-8daa-451d-a1a7-bfdafbd89d7b.gif)



### ToDo 📆 (남은 작업)
- #33 
- [ ] 식당 별 식단 카드 UI 구현

### 이후 이슈
- [ ] PostechMenuModel
- [ ] PostechMenuStateHolder
- [ ] URLSession 
- [ ] 색상 추가 및 적용


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 코드 양이 많지만 UI 작업들이라 감안하고 봐주시면 감사하겠습니다 ..! 😓
