### PR TITLE
TextField의 검색 내용 여부에 따라 이벤트를 처리합니다

### DIFF
--- a/Module-MeetUP/Module-MeetUP/App/Module_MeetUPApp.swift
+++ b/Module-MeetUP/Module-MeetUP/App/Module_MeetUPApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct Module_MeetUPApp: App {
     var body: some Scene {
         WindowGroup {
-            MainView()
+            SearchView(searchStates: SearchStateHolder())
         }
     }
 }

--- a/Module-MeetUP/Module-MeetUP/App/Module_MeetUPApp.swift
+++ b/Module-MeetUP/Module-MeetUP/App/Module_MeetUPApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct Module_MeetUPApp: App {
     var body: some Scene {
         WindowGroup {
-            SearchView(searchStates: SearchStateHolder())
+            MainView()
         }
     }
 }

--- a/Module-MeetUP/Module-MeetUP/Screens/Search/SearchViewComponents/SearchBarView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/Search/SearchViewComponents/SearchBarView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SearchBarView: View {
     //TODO: 임시 텍스트필드 변수 변경 예정
-    @available(iOS 15, *) @FocusState private var focus: Bool
+    @FocusState private var focus: Bool
     @StateObject var searchStates: SearchStateHolder
     var body: some View {
         HStack(spacing: .zero){

--- a/Module-MeetUP/Module-MeetUP/Screens/Search/SearchViewComponents/SearchBarView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/Search/SearchViewComponents/SearchBarView.swift
@@ -28,6 +28,11 @@ struct SearchBarView: View {
             TextField("찾고싶은 제목, 내용을 입력해주세요", text: $searchStates.searchContent)
                 .font(.callout)
                 .focused($focus)
+                .onSubmit {
+                    if !searchStates.searchContent.isEmpty {
+                        searchStates.updateSearchContent()
+                    }
+                }
                 .onAppear {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                         self.focus = true

--- a/Module-MeetUP/Module-MeetUP/Screens/Search/SearchViewComponents/SearchBarView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/Search/SearchViewComponents/SearchBarView.swift
@@ -23,6 +23,7 @@ struct SearchBarView: View {
                     .frame(height: 18)
                     .foregroundColor(.gray)
             }
+            .disabled(searchStates.searchContent.isEmpty)
             .padding(.trailing, 9)
             TextField("찾고싶은 제목, 내용을 입력해주세요", text: $searchStates.searchContent)
                 .font(.callout)
@@ -42,6 +43,7 @@ struct SearchBarView: View {
                     .frame(height: 18)
                     .foregroundColor(.gray)
             }
+            .disabled(searchStates.searchContent.isEmpty)
 
         }
         .padding(EdgeInsets(top: 12, leading: 22, bottom: 12, trailing: 12))


### PR DESCRIPTION
### Motivation 🥳 (코드를 추가/변경하게 된 이유)
TextField 의 검색 내용 여부에 따라서 키보드와 검색버튼, 삭제버튼의 이벤트를 분기처리했습니다.


### Key Changes 🔥 (주요 구현/변경 사항)
- `searchStates.searchContent` 가 비어있을 시에 검색바의 검색버튼과 삭제버튼을 비활성화합니다
- `searchStates.searchContent` 가 있을 시에 키보드의 return key를 눌렀을 때 검색 버튼과 동일한 이벤트가 이루어지도록 분기처리 했습니다.
- #32 의 코드리뷰를 반영하여 iOS 버전 타겟팅 코드를 제거했습니다

주요 코드는
버튼 비활성화는 `.disabled(searchStates.searchContent.isEmpty)`
키보드 이벤트 처리는 
```swift
.onSubmit {
    if !searchStates.searchContent.isEmpty {
        searchStates.updateSearchContent()
    }
}
```
 으로 처리했습니다.


### ScreenShot 📷 (참고 사진)

https://user-images.githubusercontent.com/103012087/202895421-cc0c4da4-fb3a-429f-8509-2eb27c63f7ac.MP4




### ToDo 📆 (남은 작업)
- [ ] 네트워크 처리
- [ ] PostsListView 와 연결


### Reference 🔗
[키보드 이벤트 처리](https://ios-development.tistory.com/1068)


### Close Issues 🔒 (닫을 Issue)
Close #38 #31


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 키보드의 검색 내용이 따로 없을 시에는 디폴트로 키보드가 내려가게만 하면 될 것 같아서 따로 처리하지 않았습니다.
- 추가적인 이벤트 처리가 필요하다면 리뷰 부탁드립니다 !
