### PR TITLE
전체 게시물 리스트의 당겨서 새로고침 UI를 구현합니다

### DIFF
--- a/Module-MeetUP/Module-MeetUP/Screens/PostsListView/PostsListView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostsListView/PostsListView.swift
@@ -9,17 +9,10 @@ import SwiftUI
 
 struct PostsListView: View {
     var body: some View {
-        ZStack {
-            Rectangle()
-                .fill(.gray)
-                .frame(width: .infinity, height: .infinity)
             VStack(alignment: .leading, spacing: .zero) {
                 PostsListTitleView()
                     .background(.white)
-                RefreshableScrollView(onRefresh: { refreshDone in
-                    //TODO: 새로고침될 항목 들어갈 부분
-                    refreshDone()
-                }) {
+                List {
                     VStack(spacing: .zero) {
                         ForEach(0 ..< 10, id: \.self) { _ in
                             PostCell()
@@ -29,11 +22,17 @@ struct PostsListView: View {
                     }
                     .background(.white)
                 }
+                .listStyle(PlainListStyle())
+                .refreshable {
+                    //TODO: 새로고침 시 들어갈 로직
+                }
+                .onAppear {
+                    UIRefreshControl.appearance().backgroundColor = .gray
+                }
             }
             .ignoresSafeArea()
         }
     }
-}
 
 struct PostsListView_Previews: PreviewProvider {
     static var previews: some View {

--- a/Module-MeetUP/Module-MeetUP/Screens/PostsListView/PostsListView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostsListView/PostsListView.swift
@@ -29,7 +29,6 @@ struct PostsListView: View {
                 }
             }
             .ignoresSafeArea()
-            //.background(.white)
         }
     }
 }

--- a/Module-MeetUP/Module-MeetUP/Screens/PostsListView/PostsListView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostsListView/PostsListView.swift
@@ -9,22 +9,28 @@ import SwiftUI
 
 struct PostsListView: View {
     var body: some View {
-        VStack(alignment: .leading, spacing: .zero) {
-            PostsListTitleView()
-            RefreshableScrollView(onRefresh: { refreshDone in
-                //TODO: 새로고침될 항목 들어갈 부분
-                refreshDone()
-            }) {
-                VStack(spacing: .zero) {
-                    ForEach(0 ..< 10, id: \.self) { _ in
-                        PostCell()
-                        Divider()
+        ZStack {
+            Color.gray.frame(width: .infinity, height: .infinity)
+            VStack(alignment: .leading, spacing: .zero) {
+                PostsListTitleView()
+                    .background(.white)
+                RefreshableScrollView(onRefresh: { refreshDone in
+                    //TODO: 새로고침될 항목 들어갈 부분
+                    refreshDone()
+                }) {
+                    VStack(spacing: .zero) {
+                        ForEach(0 ..< 10, id: \.self) { _ in
+                            PostCell()
+                            Divider()
+                        }
+                        Spacer()
                     }
-                    Spacer()
+                    .background(.white)
                 }
             }
+            .ignoresSafeArea()
+            //.background(.white)
         }
-        .ignoresSafeArea()
     }
 }
 

--- a/Module-MeetUP/Module-MeetUP/Screens/PostsListView/PostsListView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostsListView/PostsListView.swift
@@ -10,7 +10,9 @@ import SwiftUI
 struct PostsListView: View {
     var body: some View {
         ZStack {
-            Color.gray.frame(width: .infinity, height: .infinity)
+            Rectangle()
+                .fill(.gray)
+                .frame(width: .infinity, height: .infinity)
             VStack(alignment: .leading, spacing: .zero) {
                 PostsListTitleView()
                     .background(.white)

--- a/Module-MeetUP/Module-MeetUP/Screens/PostsListView/PostsListViewComponents/PostCell.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostsListView/PostsListViewComponents/PostCell.swift
@@ -34,7 +34,7 @@ struct PostCell: View {
                 .padding(.trailing, 7)
             PostCommentView()
         }
-        .padding(EdgeInsets(top: 25, leading: 20, bottom: 20, trailing: 20))
+        .padding(EdgeInsets(top: 25, leading: .zero, bottom: 20, trailing: .zero))
     }
 }
 

--- a/Module-MeetUP/Module-MeetUP/Screens/PostsListView/PostsListViewComponents/RefreshableScrollView.swift
+++ b/Module-MeetUP/Module-MeetUP/Screens/PostsListView/PostsListViewComponents/RefreshableScrollView.swift
@@ -71,9 +71,7 @@ struct RefreshableScrollView<Content: View>: View {
                         .foregroundColor(.gray)
                         .frame(height: THRESHOLD)
                     
-                    ActivityIndicator(isAnimating: state == .loading) {
-                        $0.hidesWhenStopped = false
-                    }
+                    ProgressView()
                     
                 }.offset(y: (state == .loading) ? 0 : -THRESHOLD)
             }
@@ -100,27 +98,5 @@ struct RefreshableScrollView<Content: View>: View {
                 }
             }
         }
-    }
-}
-
-struct ActivityIndicator: UIViewRepresentable {
-    public typealias UIView = UIActivityIndicatorView
-    public var isAnimating: Bool = true
-    public var configuration = { (indicator: UIView) in }
-    
-    public init(isAnimating: Bool, configuration: ((UIView) -> Void)? = nil) {
-        self.isAnimating = isAnimating
-        if let configuration = configuration {
-            self.configuration = configuration
-        }
-    }
-    
-    public func makeUIView(context: UIViewRepresentableContext<Self>) -> UIView {
-        UIView()
-    }
-    
-    public func updateUIView(_ uiView: UIView, context: UIViewRepresentableContext<Self>) {
-        isAnimating ? uiView.startAnimating() : uiView.stopAnimating()
-        configuration(uiView)
     }
 }


### PR DESCRIPTION
### Motivation 🥳 (코드를 추가/변경하게 된 이유)
iOS 15가 최소 지원 버전으로 결정됨에 따라 커스텀 refreshable list가 아닌 List 내의 뷰 모디파이어를 활용하여 구현했습니다.


### Key Changes 🔥 (주요 구현/변경 사항)
커스텀 refreshable list가 아닌 List를 활용하고 List 에서의 `.refreshable` 을 사용하여 당겨서 새로고침을 구현합니다.

추후 지원버전의 변경 가능성이 있어 기존 커스텀 refreshable list의 코드는 남겨두었습니다.
`RefreshableScrollView.swift` 입니다.


### ScreenShot 📷 (참고 사진)
https://user-images.githubusercontent.com/103012087/211726357-8b3be2dd-ea4a-4bb0-8f89-88ef82304f58.mp4




### ToDo 📆 (남은 작업)
- [ ] 새로고침 로직 작성
- [ ] 필요하다면 새로고침 시간동안의 스켈레톤뷰 구현


### Reference 🔗
https://developer.apple.com/documentation/swiftui/view/refreshable(action:)


### Close Issues 🔒 (닫을 Issue)
Close #43 


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 기존 커스텀에서 List로의 수정입니다! 
크게 변경된 점이 없어 빠른 리뷰 부탁드립니다

